### PR TITLE
fix/to: slime requests must be less than or equal to memory limit

### DIFF
--- a/install/helm/hango-gateway/charts/hango-gateway/templates/base/hango-gateway/hango-gateway-deploy.yaml
+++ b/install/helm/hango-gateway/charts/hango-gateway/templates/base/hango-gateway/hango-gateway-deploy.yaml
@@ -431,9 +431,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
-            limits:
-              memory: 256Mi
             requests:
+              memory: 256Mi
+            limits:
               memory: 1024Mi
           securityContext: {}
           terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
**Description**

slime requests must be less than or equal to memory limit

**Affects**

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Test and Release
- [ ] User Experience
